### PR TITLE
FEAT: parameterised headers rest_api_source

### DIFF
--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -99,6 +99,7 @@ class RESTClient:
         path: str,
         method: HTTPMethod,
         params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
         auth: Optional[AuthBase] = None,
         hooks: Optional[Hooks] = None,
@@ -109,10 +110,14 @@ class RESTClient:
         else:
             url = join_url(self.base_url, path)
 
+        headers = headers or {}
+        if self.headers:
+            headers.update(self.headers)
+
         return Request(
             method=method,
             url=url,
-            headers=self.headers,
+            headers=headers,
             params=params,
             json=json,
             auth=auth or self.auth,
@@ -142,6 +147,7 @@ class RESTClient:
         prepared_request = self._create_request(
             path=path,
             method=method,
+            headers=kwargs.pop("headers", None),
             params=kwargs.pop("params", None),
             json=kwargs.pop("json", None),
             auth=kwargs.pop("auth", None),
@@ -160,6 +166,7 @@ class RESTClient:
         path: str = "",
         method: HTTPMethodBasic = "GET",
         params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
         auth: Optional[AuthBase] = None,
         paginator: Optional[BasePaginator] = None,
@@ -173,6 +180,7 @@ class RESTClient:
             path (str): Endpoint path for the request, relative to `base_url`.
             method (HTTPMethodBasic): HTTP method for the request, defaults to 'get'.
             params (Optional[Dict[str, Any]]): URL parameters for the request.
+            headers (Optional[Dict[str, Any]]): Headers for the request.
             json (Optional[Dict[str, Any]]): JSON payload for the request.
             auth (Optional[AuthBase): Authentication configuration for the request.
             paginator (Optional[BasePaginator]): Paginator instance for handling
@@ -210,7 +218,7 @@ class RESTClient:
             hooks["response"] = [raise_for_status]
 
         request = self._create_request(
-            path=path, method=method, params=params, json=json, auth=auth, hooks=hooks
+            path=path, headers=headers, method=method, params=params, json=json, auth=auth, hooks=hooks
         )
 
         if paginator:

--- a/dlt/sources/rest_api/__init__.py
+++ b/dlt/sources/rest_api/__init__.py
@@ -346,6 +346,7 @@ def create_resources(
                 items: List[Dict[str, Any]],
                 method: HTTPMethodBasic,
                 path: str,
+                headers: Dict[str, Any],
                 params: Dict[str, Any],
                 paginator: Optional[BasePaginator],
                 data_selector: Optional[jsonpath.TJsonPath],
@@ -368,12 +369,13 @@ def create_resources(
                     )
 
                 for item in items:
-                    formatted_path, parent_record = process_parent_data_item(
-                        path, item, resolved_params, include_from_parent
+                    formatted_path, formatted_headers, parent_record = process_parent_data_item(
+                        path, headers, item, resolved_params, include_from_parent
                     )
 
                     for child_page in client.paginate(
                         method=method,
+                        headers=formatted_headers,
                         path=formatted_path,
                         params=params,
                         paginator=paginator,
@@ -392,6 +394,7 @@ def create_resources(
             )(
                 method=endpoint_config.get("method", "get"),
                 path=endpoint_config.get("path"),
+                headers=endpoint_config.get("headers"),
                 params=base_params,
                 paginator=paginator,
                 data_selector=endpoint_config.get("data_selector"),

--- a/dlt/sources/rest_api/typing.py
+++ b/dlt/sources/rest_api/typing.py
@@ -259,6 +259,7 @@ class Endpoint(TypedDict, total=False):
     method: Optional[HTTPMethodBasic]
     params: Optional[Dict[str, Union[ResolveParamConfig, IncrementalParamConfig, Any]]]
     json: Optional[Dict[str, Any]]
+    headers: Optional[Dict[str, Any]]
     paginator: Optional[PaginatorConfig]
     data_selector: Optional[jsonpath.TJsonPath]
     response_actions: Optional[List[ResponseAction]]

--- a/tests/sources/rest_api/configurations/test_resolve_config.py
+++ b/tests/sources/rest_api/configurations/test_resolve_config.py
@@ -1,15 +1,16 @@
 import re
 from copy import deepcopy
-
 import pytest
 from graphlib import CycleError  # type: ignore
 
+import dtl
 from dlt.sources.rest_api import (
     rest_api_resources,
     rest_api_source,
 )
 from dlt.sources.rest_api.config_setup import (
     _bind_path_params,
+    _bind_header_params,
     process_parent_data_item,
 )
 from dlt.sources.rest_api.typing import (
@@ -351,3 +352,18 @@ def test_circular_resource_bindingis_invalid() -> None:
     with pytest.raises(CycleError) as e:
         rest_api_resources(config)
     assert e.match(re.escape("'nodes are in a cycle', ['chicken', 'egg', 'chicken']"))
+
+
+def test_bind_header_params() -> None:
+    resource_with_headers: EndpointResource = {
+        "name": "test_resource",
+        "endpoint": {
+            "path": "test/path",
+            "headers": {"Authorization": "{token}"},
+            "params": {
+                "token": "test_token",
+            },
+        },
+    }
+    _bind_header_params(resource_with_headers)
+    assert resource_with_headers["endpoint"]["headers"]["Authorization"] == "test_token"

--- a/tests/sources/rest_api/test_rest_api_source.py
+++ b/tests/sources/rest_api/test_rest_api_source.py
@@ -1,5 +1,7 @@
 import dlt
 import pytest
+from unittest.mock import patch, MagicMock
+from requests import Response, Request
 
 from dlt.common.configuration.specs.config_providers_context import ConfigProvidersContainer
 
@@ -149,3 +151,109 @@ def test_dependent_resource(destination_name: str, invocation_type: str) -> None
     }
 
     assert table_counts["pokemon"] == 2
+
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+@pytest.mark.parametrize("invocation_type", ("deco", "factory"))
+@patch("dlt.sources.helpers.rest_client.client.RESTClient._send_request")
+def test_request_headers(mock: MagicMock, destination_name: str, invocation_type: str) -> None:
+    mock_resp = Response()
+    mock_resp.status_code = 200
+    mock_resp.json = lambda: {"success": "ok"}
+    mock.return_value = mock_resp
+
+    @dlt.resource
+    def authenticate():
+        yield [{"token": 1}]
+
+    base_url = "https://api.example.com"
+    config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            "headers": {"foo": "bar"}
+        },
+        "resources": [
+            {
+                "name": "chicken",
+                "endpoint": {
+                    "path": "chicken",
+                    "headers": {"token": "{token}", "num": "2"},
+                    "params": {
+                        "token": {
+                            "type": "resolve",
+                            "field": "token",
+                            "resource": "authenticate",
+                        },
+                    },
+                },
+            },
+            authenticate(),
+        ],
+    }
+
+    if invocation_type == "deco":
+        data = rest_api(**config)
+    else:
+        data = rest_api_source(config)
+    pipeline = _make_pipeline(destination_name)
+    pipeline.run(data)
+
+    mock.assert_called()
+    args, kwargs = mock.call_args
+    request_param: Request = args[0]
+
+    assert request_param.url == f"{base_url}/chicken"
+    assert request_param.headers == {"foo": "bar", "token": "1", "num": "2"}
+
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+@pytest.mark.parametrize("invocation_type", ("deco", "factory"))
+@patch("dlt.sources.helpers.rest_client.client.RESTClient._send_request")
+def test_request_headers_dynamic_key(mock: MagicMock, destination_name: str, invocation_type: str) -> None:
+    mock_resp = Response()
+    mock_resp.status_code = 200
+    mock_resp.json = lambda: {"success": "ok"}
+    mock.return_value = mock_resp
+
+    @dlt.resource
+    def authenticate():
+        yield [{"token": 1}]
+
+    base_url = "https://api.example.com"
+    config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            "headers": {"foo": "bar"}
+        },
+        "resources": [
+            {
+                "name": "chicken",
+                "endpoint": {
+                    "path": "chicken",
+                    "headers": {"{token}": "{token}", "num": "2"},
+                    "params": {
+                        "token": {
+                            "type": "resolve",
+                            "field": "token",
+                            "resource": "authenticate",
+                        },
+                    },
+                },
+            },
+            authenticate(),
+        ],
+    }
+
+    if invocation_type == "deco":
+        data = rest_api(**config)
+    else:
+        data = rest_api_source(config)
+    pipeline = _make_pipeline(destination_name)
+    pipeline.run(data)
+
+    mock.assert_called()
+    args, kwargs = mock.call_args
+    request_param: Request = args[0]
+
+    assert request_param.url == f"{base_url}/chicken"
+    assert request_param.headers == {"foo": "bar", "1": "1", "num": "2"}


### PR DESCRIPTION
### Description
This pull request addresses the feature request discussed in issue #2071. It introduces dynamic parameter resolution for headers, allowing both keys and values to be resolved dynamically.


### Key Features
- Dynamic Header Resolution: Supports resolving both header keys and values at runtime using specified parameters.
- Header params can also be bound to provided params
- You can still define headers in the client, these will always be used. Endpoint specific parameters extend this dict.

### Usage
The feature is demonstrated with the following example:
`
{
    "name": "chicken",
    "endpoint": {
        "path": "chicken",
        "headers": {"{token}": "{token}", "num": "2"},
        "params": {
            "token": {
                "type": "resolve",
                "field": "token",
                "resource": "authenticate",
            },
        },
    },
}
`
### Tests
Comprehensive tests have been added to validate the implementation and ensure its correctness.
